### PR TITLE
Major refactoring of data structures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ r_packages:
  - devtools
 
 r_github_packages:
- - rqtl/qtl2geno
- - rqtl/qtl2scan
+ - kbroman/qtl2geno@refactor
+ - kbroman/qtl2scan@refactor
 
 warnings_are_errors: true
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2convert
-Version: 0.2-1
-Date: 2017-03-06
+Version: 0.5-1
+Date: 2017-03-07
 Title: Convert Data among R/qtl2, R/qtl, and DOQTL
 Description: Functions to convert data structures among the R/qtl2, R/qtl, and DOQTL packages.
 Author: Karl W Broman <kbroman@biostat.wisc.edu>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,8 @@ Suggests:
     devtools,
     roxygen2,
     qtl,
-    qtl2geno,
-    qtl2scan
+    qtl2geno (>= 0.5-4),
+    qtl2scan (>= 0.5-2)
 License: GPL-3
 URL: https://github.com/rqtl/qtl2convert
 LinkingTo: Rcpp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Suggests:
     roxygen2,
     qtl,
     qtl2geno (>= 0.5-4),
-    qtl2scan (>= 0.5-2)
+    qtl2scan (>= 0.5-3)
 License: GPL-3
 URL: https://github.com/rqtl/qtl2convert
 LinkingTo: Rcpp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2convert
-Version: 0.1-5
-Date: 2016-05-24
+Version: 0.2-1
+Date: 2017-03-06
 Title: Convert Data among R/qtl2, R/qtl, and DOQTL
 Description: Functions to convert data structures among the R/qtl2, R/qtl, and DOQTL packages.
 Author: Karl W Broman <kbroman@biostat.wisc.edu>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,4 @@ License: GPL-3
 URL: https://github.com/rqtl/qtl2convert
 LinkingTo: Rcpp
 LazyData: true
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,10 @@
+## qtl2convert 0.5-1
+
+### New features
+
+- Revised `probs_doqtl_to_qtl2` and `scan_qtl2_to_qtl` to deal with
+  changes to R/qtl2 data structures in
+  [qtl2geno](https://github.com/rqtl/qtl2geno) and
+  [qtl2scan](https://github.com/rqtl/qtl2scan). Each function now
+  needs a `map` object, generally created by
+  `qtl2geno::insert_pseudomarkers()`.

--- a/R/map_df_to_list.R
+++ b/R/map_df_to_list.R
@@ -19,6 +19,12 @@
 #'
 #' @return A list of vectors of marker positions, one component per chromosome
 #'
+#' @examples
+#' map <- data.frame(chr=c(1,1,1,  2,2,2,   "X","X"),
+#'                   pos=c(0,5,10, 0,8,16,  5,20),
+#'                   marker=c("D1M1","D1M2","D1M3",    "D2M1","D2M2","D2M3",   "DXM1","DXM2"))
+#' map_list <- map_df_to_list(map, pos_column="pos")
+#'
 #' @export
 map_df_to_list <-
     function(map, chr_column="chr", pos_column="cM", marker_column="marker",

--- a/R/map_df_to_list.R
+++ b/R/map_df_to_list.R
@@ -11,13 +11,18 @@
 #' @param marker_column Name of the column in \code{map} that contains
 #' the marker names. If NULL, use the row names.
 #'
+#' @param Xchr Vector of character strings indicating the name or
+#' names of the X chromosome. If NULL, assume there's no X
+#' chromosome.
+#'
 #' @seealso \code{\link{map_list_to_df}}
 #'
 #' @return A list of vectors of marker positions, one component per chromosome
 #'
 #' @export
 map_df_to_list <-
-    function(map, chr_column="chr", pos_column="cM", marker_column="marker")
+    function(map, chr_column="chr", pos_column="cM", marker_column="marker",
+             Xchr=c("x", "X"))
 {
     if(is.null(marker_column)) {
         marker_column <- "qtl2tmp_marker"
@@ -40,6 +45,17 @@ map_df_to_list <-
     marker <- split(marker, factor(chr, levels=uchr))
     for(i in seq(along=result))
         names(result[[i]]) <- marker[[i]]
+
+    is_x_chr <- rep(FALSE, length(result))
+    names(is_x_chr) <- names(result)
+    if(!is.null(Xchr)) {
+        Xchr_used <- Xchr %in% names(is_x_chr)
+        if(any(Xchr_used)) {
+            Xchr <- Xchr[Xchr_used]
+            is_x_chr[Xchr] <- TRUE
+        }
+    }
+    attr(result, "is_x_chr") <- is_x_chr
 
     result
 }

--- a/R/map_list_to_df.R
+++ b/R/map_list_to_df.R
@@ -15,6 +15,11 @@
 #'
 #' @return A data frame with the marker positions.
 #'
+#' @examples
+#' library(qtl2geno)
+#' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
+#' iron_map <- map_list_to_df(iron$gmap)
+#'
 #' @export
 map_list_to_df <-
     function(map_list, chr_column="chr", pos_column="pos", marker_column="marker")

--- a/R/probs_doqtl_to_qtl2.R
+++ b/R/probs_doqtl_to_qtl2.R
@@ -13,7 +13,7 @@
 #' @param marker_column Name of the column in \code{map} that contains
 #' the marker names. If NULL, use the row names.
 #'
-#' @return An object of the for produced by the R/qtl2geno function \code{calc_genoprob}.
+#' @return An object of the form produced by \code{\link[qtl2geno]{calc_genoprob}}.
 #'
 #' @export
 probs_doqtl_to_qtl2 <-
@@ -56,9 +56,6 @@ probs_doqtl_to_qtl2 <-
     probs <- newprobs
     rm(newprobs)
 
-    # convert map to list
-    map <- map_df_to_list(map, chr_column, pos_column, marker_column)
-
     is_x_chr <- (uchr=="X")
     names(is_x_chr) <- uchr
 
@@ -70,14 +67,11 @@ probs_doqtl_to_qtl2 <-
         warning("Order of genotypes may be incorrect.") ## FIX_ME
     }
 
-    result <- list(probs=probs,
-                   map=map,
-                   is_x_chr=is_x_chr,
-                   crosstype="do",
-                   alleles=LETTERS[1:8],
-                   alleleprobs=alleleprobs)
-    # missing sex and cross_info
+    attr(probs, "is_x_chr") <- is_x_chr
+    attr(probs, "crosstype") <- "do"
+    attr(probs, "alleles") <- LETTERS[1:8]
+    attr(probs, "alleleprobs") <- alleleprobs
 
-    class(result) <- c("calc_genoprob", "list")
-    result
+    class(probs) <- c("calc_genoprob", "list")
+    probs
 }

--- a/man/count_unique_geno.Rd
+++ b/man/count_unique_geno.Rd
@@ -28,4 +28,3 @@ count_unique_geno(g)
 \seealso{
 \code{\link{find_unique_geno}}
 }
-

--- a/man/encode_geno.Rd
+++ b/man/encode_geno.Rd
@@ -30,4 +30,3 @@ encode_geno(geno, codes)
 \seealso{
 \code{\link{find_consensus_geno}}, \code{\link{find_unique_geno}}
 }
-

--- a/man/find_consensus_geno.Rd
+++ b/man/find_consensus_geno.Rd
@@ -29,4 +29,3 @@ find_consensus_geno(g)
 \seealso{
 \code{\link{find_consensus_geno}}, \code{\link{find_unique_geno}}
 }
-

--- a/man/find_unique_geno.Rd
+++ b/man/find_unique_geno.Rd
@@ -31,4 +31,3 @@ find_unique_geno(g)
 \seealso{
 \code{\link{count_unique_geno}}, \code{\link{encode_geno}}
 }
-

--- a/man/map_df_to_list.Rd
+++ b/man/map_df_to_list.Rd
@@ -26,4 +26,3 @@ Convert a marker map organized as data frame to a list
 \seealso{
 \code{\link{map_list_to_df}}
 }
-

--- a/man/map_df_to_list.Rd
+++ b/man/map_df_to_list.Rd
@@ -27,6 +27,13 @@ A list of vectors of marker positions, one component per chromosome
 \description{
 Convert a marker map organized as data frame to a list
 }
+\examples{
+map <- data.frame(chr=c(1,1,1,  2,2,2,   "X","X"),
+                  pos=c(0,5,10, 0,8,16,  5,20),
+                  marker=c("D1M1","D1M2","D1M3",    "D2M1","D2M2","D2M3",   "DXM1","DXM2"))
+map_list <- map_df_to_list(map, pos_column="pos")
+
+}
 \seealso{
 \code{\link{map_list_to_df}}
 }

--- a/man/map_df_to_list.Rd
+++ b/man/map_df_to_list.Rd
@@ -5,7 +5,7 @@
 \title{Marker map data frame to list}
 \usage{
 map_df_to_list(map, chr_column = "chr", pos_column = "cM",
-  marker_column = "marker")
+  marker_column = "marker", Xchr = c("x", "X"))
 }
 \arguments{
 \item{map}{Data frame with marker map}
@@ -16,6 +16,10 @@ map_df_to_list(map, chr_column = "chr", pos_column = "cM",
 
 \item{marker_column}{Name of the column in \code{map} that contains
 the marker names. If NULL, use the row names.}
+
+\item{Xchr}{Vector of character strings indicating the name or
+names of the X chromosome. If NULL, assume there's no X
+chromosome.}
 }
 \value{
 A list of vectors of marker positions, one component per chromosome

--- a/man/map_list_to_df.Rd
+++ b/man/map_list_to_df.Rd
@@ -26,4 +26,3 @@ Convert a marker map organized as a list to a data frame
 \seealso{
 \code{\link{map_df_to_list}}
 }
-

--- a/man/map_list_to_df.Rd
+++ b/man/map_list_to_df.Rd
@@ -23,6 +23,12 @@ A data frame with the marker positions.
 \description{
 Convert a marker map organized as a list to a data frame
 }
+\examples{
+library(qtl2geno)
+iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
+iron_map <- map_list_to_df(iron$gmap)
+
+}
 \seealso{
 \code{\link{map_df_to_list}}
 }

--- a/man/probs_doqtl_to_qtl2.Rd
+++ b/man/probs_doqtl_to_qtl2.Rd
@@ -25,4 +25,3 @@ An object of the for produced by the R/qtl2geno function \code{calc_genoprob}.
 \description{
 Convert DOQTL genotype probabilities to R/qtl2 format
 }
-

--- a/man/probs_doqtl_to_qtl2.Rd
+++ b/man/probs_doqtl_to_qtl2.Rd
@@ -20,7 +20,7 @@ probs_doqtl_to_qtl2(probs, map, chr_column = "chr", pos_column = "cM",
 the marker names. If NULL, use the row names.}
 }
 \value{
-An object of the for produced by the R/qtl2geno function \code{calc_genoprob}.
+An object of the form produced by \code{\link[qtl2geno]{calc_genoprob}}.
 }
 \description{
 Convert DOQTL genotype probabilities to R/qtl2 format

--- a/man/scan_qtl2_to_qtl.Rd
+++ b/man/scan_qtl2_to_qtl.Rd
@@ -34,4 +34,3 @@ out <- scan1(probs, pheno, addcovar=covar, Xcovar=Xcovar)
 out_rev <- scan_qtl2_to_qtl(out)
 
 }
-

--- a/man/scan_qtl2_to_qtl.Rd
+++ b/man/scan_qtl2_to_qtl.Rd
@@ -4,16 +4,18 @@
 \alias{scan_qtl2_to_qtl}
 \title{Convert scan1 results to the scanone format}
 \usage{
-scan_qtl2_to_qtl(scan_output)
+scan_qtl2_to_qtl(scan1_output, map)
 }
 \arguments{
-\item{scan_output}{Matrix of LOD scores, as calculated by
-\code{qtl2::scan1}.}
+\item{scan1_output}{Matrix of LOD scores, as calculated by
+\code{\link[qtl2scan]{scan1}}.}
+
+\item{map}{Map of markers/pseudomarkers (as a list of vectors).}
 }
 \value{
 A data frame with class \code{"scanone"}, containing
 chromosome and position columns followed by the LOD scores in
-\code{scan_output}.
+\code{scan1_output}.
 }
 \description{
 Convert the results of \code{qtl2::scan1}
@@ -23,7 +25,8 @@ to the form used by the R/qtl function
 \examples{
 library(qtl2geno)
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
-probs <- calc_genoprob(iron, step=1, error_prob=0.002)
+map <- insert_pseudomarkers(iron$gmap, step=1)
+probs <- calc_genoprob(iron, map, error_prob=0.002)
 pheno <- iron$pheno
 covar <- match(iron$covar$sex, c("f", "m")) # make numeric
 names(covar) <- rownames(iron$covar)
@@ -31,6 +34,6 @@ Xcovar <- get_x_covar(iron)
 library(qtl2scan)
 out <- scan1(probs, pheno, addcovar=covar, Xcovar=Xcovar)
 
-out_rev <- scan_qtl2_to_qtl(out)
+out_rev <- scan_qtl2_to_qtl(out, map)
 
 }

--- a/man/write2csv.Rd
+++ b/man/write2csv.Rd
@@ -38,4 +38,3 @@ colnames(x)[1:nc + 1] <- paste0("col", 1:nc)
 \dontrun{
 write2csv(x, "/tmp/tmpfile.csv", "A file created by write2csv")}
 }
-

--- a/tests/testthat/test-map_df_to_list.R
+++ b/tests/testthat/test-map_df_to_list.R
@@ -38,6 +38,7 @@ test_that("map_df_to_list works", {
                                .Names = c("JAX00708681",
                                "JAX00708630r", "UNCHS048201", "JAX00176676", "UNCHS048205"
                                ))), .Names = c("1", "2", "10", "X"))
+    attr(expected, "is_x_chr") <- c("1"=FALSE, "2"=FALSE, "10"=FALSE, "X"=TRUE)
 
     expect_equal(map_df_to_list(df), expected)
 

--- a/tests/testthat/test-map_list_to_df.R
+++ b/tests/testthat/test-map_list_to_df.R
@@ -17,6 +17,7 @@ test_that("map_list_to_df works", {
                                .Names = c("JAX00708681",
                                "JAX00708630r", "UNCHS048201", "JAX00176676", "UNCHS048205"
                                ))), .Names = c("1", "2", "10", "X"))
+    attr(map_list, "is_x_chr") <- c("1"=FALSE, "2"=FALSE, "10"=FALSE, "X"=TRUE)
 
     expected <-  structure(list(chr = c("1", "1", "1", "1", "1",
                                 "2", "2", "2", "2", "2", "10", "10", "10",

--- a/tests/testthat/test-probs_doqtl_to_qtl2.R
+++ b/tests/testthat/test-probs_doqtl_to_qtl2.R
@@ -20,12 +20,11 @@ test_that("probs_doqtl_to_qtl2 works", {
     expect_error( probs_doqtl_to_qtl2(p, map) ) # no pos column
     result <- probs_doqtl_to_qtl2(p, map, pos_column="Mbp")
 
-    expected <- list(probs=list("1"=p[,,1:5], "2"=p[,,6:10]),
-                     map=map_df_to_list(map, pos_column="Mbp"),
-                     is_x_chr=c("1"=FALSE,"2"=FALSE),
-                     crosstype="do",
-                     alleles=LETTERS[1:8],
-                     alleleprobs=TRUE)
+    expected <- list("1"=p[,,1:5], "2"=p[,,6:10])
+    attr(expected, "is_x_chr") <- c("1"=FALSE,"2"=FALSE)
+    attr(expected, "crosstype") <- "do"
+    attr(expected, "alleles") <- LETTERS[1:8]
+    attr(expected, "alleleprobs") <- TRUE
     class(expected) <- c("calc_genoprob", "list")
 
     expect_equal( result, expected )

--- a/tests/testthat/test-scan_qtl2_to_qtl.R
+++ b/tests/testthat/test-scan_qtl2_to_qtl.R
@@ -18,7 +18,9 @@ test_that("scan_qtl2_to_qtl works", {
 
     library(qtl2geno)
     hyper2 <- convert2cross2(hyper)
-    pr <- calc_genoprob(hyper2, pseudomarker_map = pmap, err=0.01)
+    map <- insert_pseudomarkers(pull.map(hyper), pseudomarker_map=pmap)
+
+    pr <- calc_genoprob(hyper2, map, err=0.01)
     library(qtl2scan)
     out_scan1 <- scan1(pr, hyper$pheno[,1,drop=FALSE])
 
@@ -27,7 +29,7 @@ test_that("scan_qtl2_to_qtl works", {
     for(atname in c("method", "type", "model"))
         attr(out_scanone, atname) <- NULL
 
-    out_conv <- scan_qtl2_to_qtl(out_scan1)
+    out_conv <- scan_qtl2_to_qtl(out_scan1, map)
     expect_equal(out_conv, out_scanone)
 
 })


### PR DESCRIPTION
Revised the format of the output of `calc_genoprob` and `scan1` to no longer include the map of marker/pseudomarker positions.

See <http://kbroman.org/qtl2/assets/vignettes/version05_new.html>.