### PR TITLE
Small changes to get qtl2convert on CRAN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@ language: r
 sudo: false
 cache: packages
 
-r_packages:
- - devtools
-
-r_github_packages:
- - rqtl/qtl2
-
 warnings_are_errors: true
 
 notifications:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2convert
-Version: 0.22
-Date: 2020-05-21
+Version: 0.22-2
+Date: 2020-06-02
 Title: Convert Data among QTL Mapping Packages
 Description: Functions to convert data structures among the 'R/qtl2', 'R/qtl', and 'DOQTL' packages.
 Author: Karl W Broman [aut, cre] (<https://orcid.org/0000-0002-4914-6671>)
@@ -26,6 +26,6 @@ LinkingTo: Rcpp
 LazyData: true
 Encoding: UTF-8
 ByteCompile: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 Roxygen: list(markdown=TRUE)
 Remotes: rqtl/qtl2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: qtl2convert
-Version: 0.22-5
+Version: 0.22-6
 Date: 2020-06-28
 Title: Convert Data among QTL Mapping Packages
 Description: Functions to convert data structures among the 'R/qtl2', 'R/qtl', and 'DOQTL' packages.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: qtl2convert
 Version: 0.22
 Date: 2020-05-21
-Title: Convert Data among R/qtl2, R/qtl, and DOQTL
-Description: Functions to convert data structures among the R/qtl2, R/qtl, and DOQTL packages.
+Title: Convert Data among QTL Mapping Packages
+Description: Functions to convert data structures among the 'R/qtl2', 'R/qtl', and 'DOQTL' packages.
 Author: Karl W Broman [aut, cre] (<https://orcid.org/0000-0002-4914-6671>)
 Maintainer: Karl W Broman <broman@wisc.edu>
 Authors@R: c(person("Karl W", "Broman", role=c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2convert
-Version: 0.22-4
-Date: 2020-06-14
+Version: 0.22-5
+Date: 2020-06-26
 Title: Convert Data among QTL Mapping Packages
 Description: Functions to convert data structures among the 'R/qtl2', 'R/qtl', and 'DOQTL' packages.
 Author: Karl W Broman [aut, cre] (<https://orcid.org/0000-0002-4914-6671>)
@@ -28,4 +28,3 @@ Encoding: UTF-8
 ByteCompile: true
 RoxygenNote: 7.1.0
 Roxygen: list(markdown=TRUE)
-Remotes: rqtl/qtl2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: qtl2convert
 Version: 0.22-5
-Date: 2020-06-26
+Date: 2020-06-28
 Title: Convert Data among QTL Mapping Packages
 Description: Functions to convert data structures among the 'R/qtl2', 'R/qtl', and 'DOQTL' packages.
 Author: Karl W Broman [aut, cre] (<https://orcid.org/0000-0002-4914-6671>)
 Maintainer: Karl W Broman <broman@wisc.edu>
-Authors@R: c(person("Karl W", "Broman", role=c("aut", "cre"),
-             email="broman@wisc.edu", comment=c(ORCID = "0000-0002-4914-6671")))
+Authors@R: person("Karl W", "Broman", role=c("aut", "cre"),
+                  email="broman@wisc.edu", comment=c(ORCID = "0000-0002-4914-6671"))
 Depends:
     R (>= 3.1.0)
 Imports:
@@ -26,5 +26,5 @@ LinkingTo: Rcpp
 LazyData: true
 Encoding: UTF-8
 ByteCompile: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Roxygen: list(markdown=TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2convert
-Version: 0.22-3
-Date: 2020-06-04
+Version: 0.22-4
+Date: 2020-06-14
 Title: Convert Data among QTL Mapping Packages
 Description: Functions to convert data structures among the 'R/qtl2', 'R/qtl', and 'DOQTL' packages.
 Author: Karl W Broman [aut, cre] (<https://orcid.org/0000-0002-4914-6671>)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2convert
-Version: 0.22-2
-Date: 2020-06-02
+Version: 0.22-3
+Date: 2020-06-04
 Title: Convert Data among QTL Mapping Packages
 Description: Functions to convert data structures among the 'R/qtl2', 'R/qtl', and 'DOQTL' packages.
 Author: Karl W Broman [aut, cre] (<https://orcid.org/0000-0002-4914-6671>)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: qtl2convert
-Version: 0.22-6
-Date: 2020-06-28
+Version: 0.22-7
+Date: 2020-06-30
 Title: Convert Data among QTL Mapping Packages
-Description: Functions to convert data structures among the 'R/qtl2', 'R/qtl', and 'DOQTL' packages.
+Description: Functions to convert data structures among the 'qtl2', 'qtl', and 'DOQTL' packages for mapping quantitative trait loci (QTL).
 Author: Karl W Broman [aut, cre] (<https://orcid.org/0000-0002-4914-6671>)
 Maintainer: Karl W Broman <broman@wisc.edu>
 Authors@R: person("Karl W", "Broman", role=c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2convert 0.22-6 (2020-06-28)
+## qtl2convert 0.22-7 (2020-06-30)
 
 ## Minor changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2convert 0.22-4 (2020-06-14)
+## qtl2convert 0.22-5 (2020-06-26)
 
 ## Minor changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2convert 0.22-3 (2020-06-04)
+## qtl2convert 0.22-4 (2020-06-14)
 
 ## Minor changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2convert 0.22-5 (2020-06-28)
+## qtl2convert 0.22-6 (2020-06-28)
 
 ## Minor changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+## qtl2convert 0.22-3 (2020-06-04)
+
+## Minor changes
+
+Cosmetic changes to prepare for posting to CRAN:
+
+- Revise package title and description.
+
+- Revise multi-core tests to never use >2 cores, even locally
+
+- Revise example for write2csv to use R's temporary directory
+
+- Fix link to DOQTL, which is no longer in bioconductor release
+
+
 ## qtl2convert 0.22 (2020-05-21)
 
 ### New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2convert 0.22-5 (2020-06-26)
+## qtl2convert 0.22-5 (2020-06-28)
 
 ## Minor changes
 

--- a/R/cbind_smother.R
+++ b/R/cbind_smother.R
@@ -19,7 +19,7 @@
 #' @examples
 #' df1 <- data.frame(x=c(1,2,3,NA,4), y=c(5,8,9,10,11), row.names=c("A", "B", "C", "D", "E"))
 #' df2 <- data.frame(z=c(7,8,0,9,10), y=c(6,NA,NA,9,10), row.names=c("A", "B", "F", "C", "D"))
-#' cbind_smother(df1, df2)
+#' df1n2 <- cbind_smother(df1, df2)
 cbind_smother <-
   function(mat1, mat2)
 {

--- a/R/cluster_util.R
+++ b/R/cluster_util.R
@@ -17,7 +17,7 @@ n_cores <-
 
 # set up a cluster
 setup_cluster <-
-    function(cores, quiet=TRUE)
+    function(cores)
 {
     if(is_cluster(cores)) return(cores)
 

--- a/R/count_unique_geno.R
+++ b/R/count_unique_geno.R
@@ -35,7 +35,7 @@ function(genotypes, na.strings=c("N", "H", "NA", ""), cores=1)
     # if no rows, return NULL
     if(nrow(genotypes)==0) return(NULL)
 
-    cores <- setup_cluster(cores, quiet=TRUE)
+    cores <- setup_cluster(cores)
 
     by_batch_func <- function(batch) .count_unique_geno(genotypes[batch,,drop=FALSE])
 

--- a/R/count_unique_geno.R
+++ b/R/count_unique_geno.R
@@ -23,7 +23,7 @@
 #'            c("NA", "NA", "NA", "A", "A"),
 #'            c("A",  "A",  "T",  "G", "G"),
 #'            c("C", "C",  "G",  "G", "NA"))
-#' count_unique_geno(g)
+#' counts <- count_unique_geno(g)
 count_unique_geno <-
 function(genotypes, na.strings=c("N", "H", "NA", ""), cores=1)
 {

--- a/R/encode_geno.R
+++ b/R/encode_geno.R
@@ -46,7 +46,7 @@ function(geno, allele_codes, output_codes=c("-", "A", "H", "B"), cores=1)
                         paste0(allele_codes[,1], allele_codes[,2]), # AB
                         paste0(allele_codes[,2], allele_codes[,1])) # BA
 
-    cores <- setup_cluster(cores, quiet=TRUE)
+    cores <- setup_cluster(cores)
     by_batch_func <- function(batch) .encode_geno(geno[batch,,drop=FALSE], geno_codes[batch,,drop=FALSE],
                                                   output_codes[c(2,4,2,4,3,3)])
     batches <- batch_vec(1:nrow(geno), n_cores=n_cores(cores))

--- a/R/encode_geno.R
+++ b/R/encode_geno.R
@@ -23,7 +23,7 @@
 #'               c("A", "A", "AT", "TA", "TT"),
 #'               c("T", "G", NA,   "GT", "TT"))
 #' codes <- rbind(c("C", "G"), c("A", "T"), c("T", "G"))
-#' encode_geno(geno, codes)
+#' geno_encoded <- encode_geno(geno, codes)
 #'
 encode_geno <-
 function(geno, allele_codes, output_codes=c("-", "A", "H", "B"), cores=1)

--- a/R/find_consensus_geno.R
+++ b/R/find_consensus_geno.R
@@ -35,7 +35,7 @@ function(genotypes, na.strings=c("N", "H", "NA", ""), cores=1)
     # if no rows, return NULL
     if(nrow(genotypes)==0) return(NULL)
 
-    cores <- setup_cluster(cores, quiet=TRUE)
+    cores <- setup_cluster(cores)
 
     by_batch_func <- function(batch) .find_consensus_geno(genotypes[batch,,drop=FALSE])
 

--- a/R/find_consensus_geno.R
+++ b/R/find_consensus_geno.R
@@ -24,7 +24,7 @@
 #'            c("C",  "C", "G", "G", "A", NA,  NA, NA),
 #'            rep(NA, 8),
 #'            c("C", "C", "G", "G", "G", "C", "G", "G"))
-#' find_consensus_geno(g)
+#' consensus <- find_consensus_geno(g)
 find_consensus_geno <-
 function(genotypes, na.strings=c("N", "H", "NA", ""), cores=1)
 {

--- a/R/find_unique_geno.R
+++ b/R/find_unique_geno.R
@@ -26,7 +26,7 @@
 #'            c("NA", "NA", "NA", "A", "A"),
 #'            c("A",  "A",  "T",  "G", "G"),
 #'            c("C", "C",  "G",  "G", "NA"))
-#' find_unique_geno(g)
+#' ug <- find_unique_geno(g)
 find_unique_geno <-
 function(genotypes, na.strings=c("N", "H", "NA", ""), cores=1)
 {

--- a/R/find_unique_geno.R
+++ b/R/find_unique_geno.R
@@ -38,7 +38,7 @@ function(genotypes, na.strings=c("N", "H", "NA", ""), cores=1)
     # if no rows, return NULL
     if(nrow(genotypes)==0) return(NULL)
 
-    cores <- setup_cluster(cores, quiet=TRUE)
+    cores <- setup_cluster(cores)
 
     by_batch_func <- function(batch) .find_unique_geno(genotypes[batch,,drop=FALSE])
 

--- a/R/scan_qtl_to_qtl2.R
+++ b/R/scan_qtl_to_qtl2.R
@@ -15,9 +15,6 @@
 #' out <- scanone(hyper)
 #' out2 <- scan_qtl_to_qtl2(out)
 #'
-#' library(qtl2)
-#' plot(out2$scan1, out2$map)
-#'
 #' @seealso [scan_qtl_to_qtl2()]
 #'
 #' @export

--- a/R/write2csv.R
+++ b/R/write2csv.R
@@ -15,6 +15,8 @@
 #' @param overwrite If TRUE, overwrite file if it exists. If FALSE
 #' (the default) and the file exists, stop with an error.
 #'
+#' @return None.
+#'
 #' @details
 #' If the file already exists, the function will refuse to write over it.
 #'

--- a/R/write2csv.R
+++ b/R/write2csv.R
@@ -39,9 +39,12 @@
 #' x <- data.frame(id=paste0("ind", 1:nr),
 #'                 matrix(rnorm(nr*nc), ncol=nc))
 #' colnames(x)[1:nc + 1] <- paste0("col", 1:nc)
-#' \dontrun{
+#'
 #' testfile <- file.path(tempdir(), "tmpfile.csv")
-#' write2csv(x, testfile, "A file created by write2csv")}
+#' write2csv(x, testfile, "A file created by write2csv")
+#'
+#' # Remove the file, to clean up temporary directory
+#' unlink(testfile)
 write2csv <-
     function(df, filename, comment="", sep=",", comment.char="#",
              row.names=NULL, overwrite=FALSE)

--- a/R/write2csv.R
+++ b/R/write2csv.R
@@ -40,7 +40,8 @@
 #'                 matrix(rnorm(nr*nc), ncol=nc))
 #' colnames(x)[1:nc + 1] <- paste0("col", 1:nc)
 #' \dontrun{
-#' write2csv(x, "/tmp/tmpfile.csv", "A file created by write2csv")}
+#' testfile <- file.path(tempdir(), "tmpfile.csv")
+#' write2csv(x, testfile, "A file created by write2csv")}
 write2csv <-
     function(df, filename, comment="", sep=",", comment.char="#",
              row.names=NULL, overwrite=FALSE)

--- a/README.md
+++ b/README.md
@@ -17,14 +17,9 @@ and [R/qtl](https://rqtl.org) formats.
 
 ### Installation
 
-Install R/qtl2 from [CRAN](https://cran.r-project.org):
+Install the qtl2convert package from [CRAN](https://cran.r-project.org):
 
-    install.packages("qtl2")
-
-Then install the [qtl2convert](https://github.com/rqtl/qtl2convert)
-package from a separate mini-CRAN.
-
-    install.packages("qtl2convert", repos="https://rqtl.org/qtl2cran")
+    install.packages("qtl2convert")
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ### R/qtl2convert
 
 [![Build Status](https://travis-ci.org/rqtl/qtl2convert.svg?branch=master)](https://travis-ci.org/rqtl/qtl2convert)
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/qtl2convert)](https://cran.r-project.org/package=qtl2convert)
 
 [Karl Broman](https://kbroman.org)
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,12 @@ and [R/qtl](https://rqtl.org) formats.
 
 ### Installation
 
-Make sure you have the latest version of [R](https://cran.r-project.org).
-Then install R/qtl2 using the following. (For more
-detail, see the instructions at <https://kbroman.org/qtl2>.)
+Install R/qtl2 from [CRAN](https://cran.r-project.org):
 
-    install.packages("qtl2", repos="https://rqtl.org/qtl2cran")
+    install.packages("qtl2")
 
 Then install the [qtl2convert](https://github.com/rqtl/qtl2convert)
-package.
+package from a separate mini-CRAN.
 
     install.packages("qtl2convert", repos="https://rqtl.org/qtl2cran")
 

--- a/man/cbind_smother.Rd
+++ b/man/cbind_smother.Rd
@@ -26,5 +26,5 @@ in its place.
 \examples{
 df1 <- data.frame(x=c(1,2,3,NA,4), y=c(5,8,9,10,11), row.names=c("A", "B", "C", "D", "E"))
 df2 <- data.frame(z=c(7,8,0,9,10), y=c(6,NA,NA,9,10), row.names=c("A", "B", "F", "C", "D"))
-cbind_smother(df1, df2)
+df1n2 <- cbind_smother(df1, df2)
 }

--- a/man/count_unique_geno.Rd
+++ b/man/count_unique_geno.Rd
@@ -28,7 +28,7 @@ g <- rbind(c("NA", "A",  "A",  "A", "T"),
            c("NA", "NA", "NA", "A", "A"),
            c("A",  "A",  "T",  "G", "G"),
            c("C", "C",  "G",  "G", "NA"))
-count_unique_geno(g)
+counts <- count_unique_geno(g)
 }
 \seealso{
 \code{\link[=find_unique_geno]{find_unique_geno()}}

--- a/man/count_unique_geno.Rd
+++ b/man/count_unique_geno.Rd
@@ -4,8 +4,7 @@
 \alias{count_unique_geno}
 \title{Count the unique genotypes for each row of a genotype matrix}
 \usage{
-count_unique_geno(genotypes, na.strings = c("N", "H", "NA", ""),
-  cores = 1)
+count_unique_geno(genotypes, na.strings = c("N", "H", "NA", ""), cores = 1)
 }
 \arguments{
 \item{genotypes}{Matrix of genotypes (markers x individuals)}

--- a/man/encode_geno.Rd
+++ b/man/encode_geno.Rd
@@ -34,7 +34,7 @@ geno <- rbind(c("C", "G", "C",  "GG", "CG"),
               c("A", "A", "AT", "TA", "TT"),
               c("T", "G", NA,   "GT", "TT"))
 codes <- rbind(c("C", "G"), c("A", "T"), c("T", "G"))
-encode_geno(geno, codes)
+geno_encoded <- encode_geno(geno, codes)
 
 }
 \seealso{

--- a/man/encode_geno.Rd
+++ b/man/encode_geno.Rd
@@ -4,8 +4,12 @@
 \alias{encode_geno}
 \title{Encode a matrix of genotypes using a set of allele codes}
 \usage{
-encode_geno(geno, allele_codes, output_codes = c("-", "A", "H", "B"),
-  cores = 1)
+encode_geno(
+  geno,
+  allele_codes,
+  output_codes = c("-", "A", "H", "B"),
+  cores = 1
+)
 }
 \arguments{
 \item{geno}{Character matrix of genotypes (rows as markers, columns as individuals)}

--- a/man/find_consensus_geno.Rd
+++ b/man/find_consensus_geno.Rd
@@ -4,8 +4,7 @@
 \alias{find_consensus_geno}
 \title{Find the consensus genotype for each row of a genotype matrix}
 \usage{
-find_consensus_geno(genotypes, na.strings = c("N", "H", "NA", ""),
-  cores = 1)
+find_consensus_geno(genotypes, na.strings = c("N", "H", "NA", ""), cores = 1)
 }
 \arguments{
 \item{genotypes}{Matrix of genotypes (markers x individuals)}

--- a/man/find_consensus_geno.Rd
+++ b/man/find_consensus_geno.Rd
@@ -29,7 +29,7 @@ g <- rbind(c("NA", "N", "A", "A", "T", "G", NA, "H"),
            c("C",  "C", "G", "G", "A", NA,  NA, NA),
            rep(NA, 8),
            c("C", "C", "G", "G", "G", "C", "G", "G"))
-find_consensus_geno(g)
+consensus <- find_consensus_geno(g)
 }
 \seealso{
 \code{\link[=find_unique_geno]{find_unique_geno()}}, \code{\link[=encode_geno]{encode_geno()}}

--- a/man/find_unique_geno.Rd
+++ b/man/find_unique_geno.Rd
@@ -31,7 +31,7 @@ g <- rbind(c("NA", "A",  "A",  "A", "T"),
            c("NA", "NA", "NA", "A", "A"),
            c("A",  "A",  "T",  "G", "G"),
            c("C", "C",  "G",  "G", "NA"))
-find_unique_geno(g)
+ug <- find_unique_geno(g)
 }
 \seealso{
 \code{\link[=count_unique_geno]{count_unique_geno()}}, \code{\link[=encode_geno]{encode_geno()}}

--- a/man/find_unique_geno.Rd
+++ b/man/find_unique_geno.Rd
@@ -4,8 +4,7 @@
 \alias{find_unique_geno}
 \title{Find the unique genotypes for each row of a genotype matrix}
 \usage{
-find_unique_geno(genotypes, na.strings = c("N", "H", "NA", ""),
-  cores = 1)
+find_unique_geno(genotypes, na.strings = c("N", "H", "NA", ""), cores = 1)
 }
 \arguments{
 \item{genotypes}{Matrix of genotypes (markers x individuals)}

--- a/man/map_df_to_list.Rd
+++ b/man/map_df_to_list.Rd
@@ -4,8 +4,13 @@
 \alias{map_df_to_list}
 \title{Marker map data frame to list}
 \usage{
-map_df_to_list(map, chr_column = "chr", pos_column = "cM",
-  marker_column = "marker", Xchr = c("x", "X"))
+map_df_to_list(
+  map,
+  chr_column = "chr",
+  pos_column = "cM",
+  marker_column = "marker",
+  Xchr = c("x", "X")
+)
 }
 \arguments{
 \item{map}{Data frame with marker map}

--- a/man/map_list_to_df.Rd
+++ b/man/map_list_to_df.Rd
@@ -4,8 +4,12 @@
 \alias{map_list_to_df}
 \title{Marker map list to data frame}
 \usage{
-map_list_to_df(map_list, chr_column = "chr", pos_column = "pos",
-  marker_column = "marker")
+map_list_to_df(
+  map_list,
+  chr_column = "chr",
+  pos_column = "pos",
+  marker_column = "marker"
+)
 }
 \arguments{
 \item{map_list}{List of vectors containing marker positions}

--- a/man/probs_doqtl_to_qtl2.Rd
+++ b/man/probs_doqtl_to_qtl2.Rd
@@ -4,8 +4,14 @@
 \alias{probs_doqtl_to_qtl2}
 \title{Convert DOQTL genotype probabilities to R/qtl2 format}
 \usage{
-probs_doqtl_to_qtl2(probs, map, is_female = NULL, chr_column = "chr",
-  pos_column = "cM", marker_column = "marker")
+probs_doqtl_to_qtl2(
+  probs,
+  map,
+  is_female = NULL,
+  chr_column = "chr",
+  pos_column = "cM",
+  marker_column = "marker"
+)
 }
 \arguments{
 \item{probs}{3d array of genotype probabilities as calculated from DOQTL

--- a/man/qtl2convert-package.Rd
+++ b/man/qtl2convert-package.Rd
@@ -4,9 +4,9 @@
 \name{qtl2convert-package}
 \alias{qtl2convert}
 \alias{qtl2convert-package}
-\title{qtl2convert: Convert Data among R/qtl2, R/qtl, and DOQTL}
+\title{qtl2convert: Convert Data among QTL Mapping Packages}
 \description{
-Functions to convert data structures among the R/qtl2, R/qtl, and DOQTL packages.
+Functions to convert data structures among the 'R/qtl2', 'R/qtl', and 'DOQTL' packages.
 }
 \section{Vignettes}{
 
@@ -29,7 +29,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Karl W Broman \email{broman@wisc.edu} (0000-0002-4914-6671)
+\strong{Maintainer}: Karl W Broman \email{broman@wisc.edu} (\href{https://orcid.org/0000-0002-4914-6671}{ORCID})
 
 }
 \keyword{internal}

--- a/man/qtl2convert-package.Rd
+++ b/man/qtl2convert-package.Rd
@@ -6,7 +6,7 @@
 \alias{qtl2convert-package}
 \title{qtl2convert: Convert Data among QTL Mapping Packages}
 \description{
-Functions to convert data structures among the 'R/qtl2', 'R/qtl', and 'DOQTL' packages.
+Functions to convert data structures among the 'qtl2', 'qtl', and 'DOQTL' packages for mapping quantitative trait loci (QTL).
 }
 \section{Vignettes}{
 

--- a/man/scan_qtl_to_qtl2.Rd
+++ b/man/scan_qtl_to_qtl2.Rd
@@ -24,9 +24,6 @@ hyper <- calc.genoprob(hyper, step=1, error.prob=0.002)
 out <- scanone(hyper)
 out2 <- scan_qtl_to_qtl2(out)
 
-library(qtl2)
-plot(out2$scan1, out2$map)
-
 }
 \seealso{
 \code{\link[=scan_qtl_to_qtl2]{scan_qtl_to_qtl2()}}

--- a/man/write2csv.Rd
+++ b/man/write2csv.Rd
@@ -33,6 +33,9 @@ to be the name for that column.}
 \item{overwrite}{If TRUE, overwrite file if it exists. If FALSE
 (the default) and the file exists, stop with an error.}
 }
+\value{
+None.
+}
 \description{
 Write a data frame to a CSV file in a special form, with info about the number of rows and columns.
 }

--- a/man/write2csv.Rd
+++ b/man/write2csv.Rd
@@ -58,7 +58,10 @@ nc <- 5
 x <- data.frame(id=paste0("ind", 1:nr),
                 matrix(rnorm(nr*nc), ncol=nc))
 colnames(x)[1:nc + 1] <- paste0("col", 1:nc)
-\dontrun{
+
 testfile <- file.path(tempdir(), "tmpfile.csv")
-write2csv(x, testfile, "A file created by write2csv")}
+write2csv(x, testfile, "A file created by write2csv")
+
+# Remove the file, to clean up temporary directory
+unlink(testfile)
 }

--- a/man/write2csv.Rd
+++ b/man/write2csv.Rd
@@ -4,8 +4,15 @@
 \alias{write2csv}
 \title{Write a data frame to a CSV file}
 \usage{
-write2csv(df, filename, comment = "", sep = ",", comment.char = "#",
-  row.names = NULL, overwrite = FALSE)
+write2csv(
+  df,
+  filename,
+  comment = "",
+  sep = ",",
+  comment.char = "#",
+  row.names = NULL,
+  overwrite = FALSE
+)
 }
 \arguments{
 \item{df}{A data frame (or matrix)}
@@ -32,7 +39,7 @@ Write a data frame to a CSV file in a special form, with info about the number o
 \details{
 If the file already exists, the function will refuse to write over it.
 
-The file will include comments at the top, using \code{#} as a
+The file will include comments at the top, using \verb{#} as a
 comment character, including the number of rows (not including the
 header) and the number of columns.
 

--- a/man/write2csv.Rd
+++ b/man/write2csv.Rd
@@ -59,5 +59,6 @@ x <- data.frame(id=paste0("ind", 1:nr),
                 matrix(rnorm(nr*nc), ncol=nc))
 colnames(x)[1:nc + 1] <- paste0("col", 1:nc)
 \dontrun{
-write2csv(x, "/tmp/tmpfile.csv", "A file created by write2csv")}
+testfile <- file.path(tempdir(), "tmpfile.csv")
+write2csv(x, testfile, "A file created by write2csv")}
 }

--- a/tests/testthat/test-count_unique_geno.R
+++ b/tests/testthat/test-count_unique_geno.R
@@ -30,12 +30,10 @@ test_that("count_unique_geno works multi-core", {
                c("C", "C",  "G",  "G", NA))
     expected <- c(2,1,3,0,1,2,2)
     expect_equal(count_unique_geno(g), expected)
-    expect_equal(count_unique_geno(g, cores=4), expected)
-    expect_equal(count_unique_geno(g, cores=0), expected)
+    expect_equal(count_unique_geno(g, cores=2), expected)
 
     rownames(g) <- names(expected) <- paste0("mar", 1:7)
     expect_equal(count_unique_geno(g), expected)
-    expect_equal(count_unique_geno(g, cores=4), expected)
-    expect_equal(count_unique_geno(g, cores=0), expected)
+    expect_equal(count_unique_geno(g, cores=2), expected)
 
 })

--- a/tests/testthat/test-encode_geno.R
+++ b/tests/testthat/test-encode_geno.R
@@ -46,15 +46,13 @@ test_that("encode_geno works multi-core", {
                       c("A", "B", "-", "H", "A"))
 
     expect_equal(encode_geno(geno, codes), expected)
-    expect_equal(encode_geno(geno, codes, cores=4), expected)
-    expect_equal(encode_geno(geno, codes, cores=0), expected)
+    expect_equal(encode_geno(geno, codes, cores=2), expected)
 
     expected2 <- gsub("Z", "A",
                       gsub("A", "B",
                            gsub("B", "Z", expected)))
 
     expect_equal(encode_geno(geno, cbind(codes[,2], codes[,1])), expected2)
-    expect_equal(encode_geno(geno, cbind(codes[,2], codes[,1]), cores=4), expected2)
-    expect_equal(encode_geno(geno, cbind(codes[,2], codes[,1]), cores=1), expected2)
+    expect_equal(encode_geno(geno, cbind(codes[,2], codes[,1]), cores=2), expected2)
 
 })

--- a/tests/testthat/test-find_consensus_geno.R
+++ b/tests/testthat/test-find_consensus_geno.R
@@ -22,12 +22,10 @@ test_that("find_consensus_geno works multi-core", {
                c("C", "C", "G", "G", "G", "C", "G", "G"))
     expected <- c("A", NA, NA, "G")
     expect_equal(find_consensus_geno(g), expected)
-    expect_equal(find_consensus_geno(g, cores=4), expected)
-    expect_equal(find_consensus_geno(g, cores=0), expected)
+    expect_equal(find_consensus_geno(g, cores=2), expected)
 
     rownames(g) <- names(expected) <- paste0("mar", 1:4)
     expect_equal(find_consensus_geno(g), expected)
-    expect_equal(find_consensus_geno(g, cores=4), expected)
-    expect_equal(find_consensus_geno(g, cores=0), expected)
+    expect_equal(find_consensus_geno(g, cores=2), expected)
 
 })

--- a/tests/testthat/test-find_unique_geno.R
+++ b/tests/testthat/test-find_unique_geno.R
@@ -40,11 +40,9 @@ test_that("find_unique_geno works multi-core", {
                       c("A", "T"),
                       c("C", "G"))
     expect_equal(find_unique_geno(g), expected)
-    expect_equal(find_unique_geno(g, cores=4), expected)
-    expect_equal(find_unique_geno(g, cores=0), expected)
+    expect_equal(find_unique_geno(g, cores=2), expected)
 
     rownames(g) <- rownames(expected) <- paste0("mar", 1:7)
     expect_equal(find_unique_geno(g), expected)
-    expect_equal(find_unique_geno(g, cores=4), expected)
-    expect_equal(find_unique_geno(g, cores=0), expected)
+    expect_equal(find_unique_geno(g, cores=2), expected)
 })


### PR DESCRIPTION
Made a number of cosmetic changes to get the package on [CRAN](https://cran.r-project.org):

- Revised package title and description.

- Revised multi-core tests to never use >2 cores, even locally

- Revised example for `write2csv()` to use R's temporary directory

- Fixed link to DOQTL, which is no longer in bioconductor release
