### PR TITLE
hom was referenced at line 139 without being defined in scope

### DIFF
--- a/R/probs_doqtl_to_qtl2.R
+++ b/R/probs_doqtl_to_qtl2.R
@@ -123,11 +123,11 @@ probs_doqtl_to_qtl2 <-
             dimnames(newprobs[[i]]) <- list(rownames(probs),
                                             c(new_geno_labels, paste0(LETTERS[1:8], "Y")),
                                             dimnames(probs)[[3]][chr==i])
+            hom <- paste0(LETTERS[1:8], LETTERS[1:8])
 
             if(is.null(is_female)) { # need to guess sex
                 het_tolerance <- 1e-4
 
-                hom <- paste0(LETTERS[1:8], LETTERS[1:8])
                 het <- old_geno_labels[!(old_geno_labels %in% hom)]
                 sum_het <- apply(probs[,het,chr==i,drop=FALSE], 1, sum)/dim(probs)[[3]]
                 is_female <- setNames((sum_het > het_tolerance), rownames(probs))


### PR DESCRIPTION
The variable 'hom' was declared and referenced in one if statement, but then is was referenced again in a lower if statement where it was out of scope. I moved the declaration of 'hom' outside of the two if statements.